### PR TITLE
Fix lens drift when multiple in-flow lenses collapse the snapshot

### DIFF
--- a/demos/comparison-scene.html
+++ b/demos/comparison-scene.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>liquidGL drift comparison scene</title>
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      html, body { width: 100%; }
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #111;
+        color: #fff;
+        overflow-x: hidden;
+      }
+
+      /* Each lens sits in a "gap" — a flow-level container with a target stripe
+         centered behind where the lens lands. The lens itself is block-level
+         (in flow), so on the upstream build html2canvas applies display:none in
+         its clone and collapses real layout space, drifting every gap below. */
+      .gap {
+        position: relative;
+        padding: 80px 0;
+        background: #1a1a1a;
+      }
+
+      .target {
+        position: absolute;
+        top: 50%;
+        left: 0;
+        right: 0;
+        height: 96px;
+        transform: translateY(-50%);
+        background: #fff;
+        color: #000;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 56px;
+        font-weight: 900;
+        letter-spacing: 24px;
+        text-indent: 24px;
+        z-index: 0;
+      }
+
+      .liquidGL {
+        position: relative;
+        display: block;
+        width: 280px;
+        height: 280px;
+        margin: 0 auto;
+        border-radius: 36px;
+        z-index: 1;
+      }
+
+      .band {
+        position: relative;
+        width: 100%;
+        height: 600px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 220px;
+        font-weight: 900;
+        letter-spacing: -8px;
+        color: rgba(255, 255, 255, 0.92);
+        text-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+      }
+
+      .band-1 { background: linear-gradient(135deg, #ff3b6b, #ff8b3b); }
+      .band-2 { background: linear-gradient(135deg, #3bcfff, #3b6bff); }
+      .band-3 { background: linear-gradient(135deg, #ffd23b, #ff8b3b); }
+      .band-4 { background: linear-gradient(135deg, #8b3bff, #ff3b9a); }
+      .band-5 { background: linear-gradient(135deg, #3bff8b, #3bcfff); }
+      .band-6 { background: linear-gradient(135deg, #ff3b3b, #8b3bff); }
+
+      /* Stripes inside bands so drift is more obvious */
+      .band::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: repeating-linear-gradient(
+          0deg,
+          rgba(0, 0, 0, 0.0) 0px,
+          rgba(0, 0, 0, 0.0) 60px,
+          rgba(0, 0, 0, 0.18) 60px,
+          rgba(0, 0, 0, 0.18) 80px
+        );
+        pointer-events: none;
+      }
+
+      .band-label {
+        position: relative;
+        z-index: 1;
+      }
+
+      .ver-tag {
+        position: fixed;
+        top: 12px;
+        left: 12px;
+        z-index: 9999;
+        background: rgba(0, 0, 0, 0.7);
+        color: #fff;
+        padding: 6px 12px;
+        border-radius: 6px;
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.5px;
+        text-transform: uppercase;
+        font-family: -apple-system, monospace;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="ver-tag" id="verTag">loading…</div>
+
+    <section class="band band-1"><span class="band-label">1</span></section>
+    <div class="gap"><div class="target">TARGET A</div><div class="liquidGL"></div></div>
+    <section class="band band-2"><span class="band-label">2</span></section>
+    <div class="gap"><div class="target">TARGET B</div><div class="liquidGL"></div></div>
+    <section class="band band-3"><span class="band-label">3</span></section>
+    <div class="gap"><div class="target">TARGET C</div><div class="liquidGL"></div></div>
+    <section class="band band-4"><span class="band-label">4</span></section>
+    <div class="gap"><div class="target">TARGET D</div><div class="liquidGL"></div></div>
+    <section class="band band-5"><span class="band-label">5</span></section>
+    <div class="gap"><div class="target">TARGET E</div><div class="liquidGL"></div></div>
+    <section class="band band-6"><span class="band-label">6</span></section>
+    <div class="gap"><div class="target">TARGET F</div><div class="liquidGL"></div></div>
+
+    <script>
+      const params = new URLSearchParams(window.location.search);
+      const ver = params.get("ver") === "upstream" ? "upstream" : "local";
+
+      const tag = document.getElementById("verTag");
+      tag.textContent = ver === "upstream" ? "Upstream (buggy)" : "Patched fork";
+      tag.style.background = ver === "upstream"
+        ? "rgba(180, 30, 30, 0.85)"
+        : "rgba(30, 130, 60, 0.85)";
+
+      const html2canvasSrc = "/scripts/html2canvas.min.js";
+      const liquidGLSrc =
+        ver === "upstream"
+          ? "https://cdn.jsdelivr.net/gh/naughtyduk/liquidGL@latest/scripts/liquidGL.js"
+          : "/scripts/liquidGL.js";
+
+      function loadScript(src) {
+        return new Promise((resolve, reject) => {
+          const s = document.createElement("script");
+          s.src = src;
+          s.onload = resolve;
+          s.onerror = reject;
+          document.head.appendChild(s);
+        });
+      }
+
+      (async () => {
+        await loadScript(html2canvasSrc);
+        await loadScript(liquidGLSrc);
+
+        liquidGL({
+          target: ".liquidGL",
+          snapshot: "body",
+          resolution: 2,
+          refraction: 0.026,
+          bevelDepth: 0.119,
+          bevelWidth: 0.057,
+          frost: 0,
+          specular: true,
+          shadow: true,
+          reveal: "fade",
+        });
+      })();
+
+      // Report scroll to parent for sync
+      window.addEventListener("scroll", () => {
+        if (window.parent !== window) {
+          window.parent.postMessage(
+            {
+              type: "liquidgl-scene-scroll",
+              ver,
+              scrollY: window.scrollY,
+              scrollHeight: document.documentElement.scrollHeight,
+              innerHeight: window.innerHeight,
+            },
+            "*"
+          );
+        }
+      });
+
+      window.addEventListener("message", (e) => {
+        const d = e.data;
+        if (!d || d.type !== "liquidgl-parent-scroll") return;
+        if (d.ver === ver) return;
+        window.scrollTo(0, d.scrollY);
+      });
+    </script>
+  </body>
+</html>

--- a/demos/comparison.html
+++ b/demos/comparison.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>liquidGL — Upstream vs Patched Fork</title>
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      html, body { width: 100%; height: 100%; }
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #0a0a0a;
+        color: #fff;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+      }
+
+      header {
+        flex: 0 0 auto;
+        padding: 14px 20px;
+        background: #0a0a0a;
+        border-bottom: 1px solid #222;
+      }
+
+      h1 {
+        font-size: 16px;
+        font-weight: 700;
+        margin-bottom: 4px;
+      }
+
+      p {
+        font-size: 12px;
+        color: #aaa;
+        line-height: 1.5;
+      }
+
+      .panes {
+        flex: 1 1 auto;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 1px;
+        background: #222;
+        min-height: 0;
+      }
+
+      .pane {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        background: #0a0a0a;
+        min-height: 0;
+      }
+
+      .pane-header {
+        flex: 0 0 auto;
+        padding: 8px 14px;
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 1px;
+        text-transform: uppercase;
+        background: #161616;
+        border-bottom: 1px solid #222;
+      }
+
+      .pane-header.upstream { color: #ff7a7a; }
+      .pane-header.fork { color: #7aff9a; }
+
+      iframe {
+        flex: 1 1 auto;
+        width: 100%;
+        border: 0;
+        background: #111;
+        min-height: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>liquidGL — Upstream vs Patched Fork</h1>
+      <p>
+        Both panes show the same long page with six lenses in normal flow, each over a labeled white target stripe. Scroll either side — the other follows.
+        On the upstream build, every lens is misaligned: each lens's own collapse shifts its target up, and each additional lens above adds more cumulative drift, so the offset grows with depth. The patched fork keeps every lens locked to its target at every scroll position.
+      </p>
+    </header>
+
+    <div class="panes">
+      <div class="pane">
+        <div class="pane-header upstream">Upstream (buggy) — naughtyduk/liquidGL@latest</div>
+        <iframe
+          id="frameUpstream"
+          src="/demos/comparison-scene.html?ver=upstream"
+          title="Upstream"
+        ></iframe>
+      </div>
+      <div class="pane">
+        <div class="pane-header fork">Patched fork — /scripts/liquidGL.js</div>
+        <iframe
+          id="frameFork"
+          src="/demos/comparison-scene.html?ver=local"
+          title="Patched"
+        ></iframe>
+      </div>
+    </div>
+
+    <script>
+      let suppress = false;
+
+      window.addEventListener("message", (e) => {
+        const d = e.data;
+        if (!d || d.type !== "liquidgl-scene-scroll") return;
+        if (suppress) return;
+        suppress = true;
+
+        const targets = [
+          document.getElementById("frameUpstream"),
+          document.getElementById("frameFork"),
+        ];
+
+        targets.forEach((frame) => {
+          frame.contentWindow.postMessage(
+            {
+              type: "liquidgl-parent-scroll",
+              ver: d.ver,
+              scrollY: d.scrollY,
+            },
+            "*"
+          );
+        });
+
+        requestAnimationFrame(() => {
+          suppress = false;
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/scripts/liquidGL.js
+++ b/scripts/liquidGL.js
@@ -446,9 +446,16 @@
             .flatMap((lens) => [lens.el, lens._shadowEl])
             .filter(Boolean);
 
+          lensElements.forEach((el) => {
+            el.setAttribute("data-liquidgl-hide", "");
+            undos.push(() => {
+              el.removeAttribute("data-liquidgl-hide");
+            });
+          });
+
           const ignoreElementsFunc = (element) => {
             if (!element || !element.hasAttribute) return false;
-            if (element === this.canvas || lensElements.includes(element)) {
+            if (element === this.canvas) {
               return true;
             }
             const style = window.getComputedStyle(element);
@@ -472,6 +479,13 @@
             scrollY: 0,
             scale: scale,
             ignoreElements: ignoreElementsFunc,
+            onclone: (clonedDoc) => {
+              clonedDoc
+                .querySelectorAll("[data-liquidgl-hide]")
+                .forEach((el) => {
+                  el.style.visibility = "hidden";
+                });
+            },
           });
 
           this._uploadTexture(snapCanvas);


### PR DESCRIPTION

## Summary

Fixes a snapshot/coord mismatch in `captureSnapshot` that caused every `.liquidGL` lens to refract the wrong region when multiple lenses sat in normal document flow on a long page. The misalignment compounded with depth, each additional lens above contributed to the offset.

## Root cause

`captureSnapshot` passed lens elements into html2canvas's `ignoreElements` callback. html2canvas honors `ignoreElements` by setting `display: none` on those elements **in its cloned DOM**, which collapses them out of layout. Any element below a collapsed lens shifts up in the snapshot by that lens's height.

Lens sampling math in `_renderLens` (`scripts/liquidGL.js:686–688`) reads the lens position from the **live** DOM:

```js
const docY = rect.top - this.snapshotTarget.getBoundingClientRect().top;
const topUV = (docY * this.scaleFactor) / this.textureHeight;
```

Live coords no longer match snapshot coords, so the UV sample lands in the wrong place. With N lenses above a given lens, the cumulative collapse is N × lens-height, so the offset grows the deeper into the page you go. Lenses with `position: absolute` mostly hid the bug because they don't contribute to flow; lenses in normal flow (block-level) make it obvious.

## Fix

Stop using `ignoreElements` to remove lens elements. Instead:

1. Tag each live lens element with a `data-liquidgl-hide` attribute before calling html2canvas (attribute mutation only — no visual repaint).
2. Pass an `onclone(clonedDoc)` handler that finds those tagged elements in the clone and sets `visibility: hidden`.
3. Remove the attribute after capture.

`visibility: hidden` preserves the element's box in layout but doesn't paint its content — so the snapshot doesn't double-render the lens, and live-DOM coords match snapshot coords exactly. The data-attribute approach matches the existing `data-liquid-ignore` pattern already in `ignoreElementsFunc`.

## Reproducing

A long page with 4+ block-level `.liquidGL` elements interspersed with content (e.g. between sections) reproduces the bug on `main`. Each lens refracts content from a position that drifts further from its true backdrop the lower it sits. The first lens is also affected because its own collapse shifts content positioned within its parent gap.

## Try the demo

Open `/demos/comparison.html` — side-by-side panes showing the upstream build (left) vs the patched fork (right) on the same scene. Scroll either side; the other follows. The patched pane keeps every lens locked to its target stripe.

## Test plan

- [ ] Existing demos (`demos/demo-1.html` … `demos/demo-5.html`) still render correctly — single-lens and absolute-positioned lens cases remain unchanged.
- [ ] On a long page with multiple in-flow `.liquidGL` lenses, every lens refracts the content directly behind it at every scroll position.
- [ ] Scroll behavior is unchanged (no flicker on the live DOM during snapshot capture, since the attribute mutation doesn't repaint).
- [ ] Snapshot recapture on resize/scroll continues to work.
